### PR TITLE
Add root home page with controller

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,0 +1,4 @@
+class HomeController < ApplicationController
+  def index
+  end
+end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,0 +1,1 @@
+<h1>Welcome to Kangaroo app</h1>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,4 @@
 Rails.application.routes.draw do
+  root 'home#index'
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe "Homes", type: :request do
+  describe "GET /" do
+    it "returns http success for root path" do
+      get root_url
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/views/home/index.html.erb_spec.rb
+++ b/spec/views/home/index.html.erb_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe "home/index.html.erb", type: :view do
+  
+  it "Should have a h1 tag with Welcome to Kangaroo app text" do 
+    render
+    expect(rendered).to match("<h1>Welcome to Kangaroo app</h1>")
+  end
+ 
+end


### PR DESCRIPTION

# Description
Add a root route to a home controller and index action with a view to print a welcome message

 Examples:
 - What?: add a root page for the landing home creation
 - Why?:  in order to have a home root in a heroku deployment

 # Testing
run the rspec command

  ## Screenshots
<img width="440" alt="Captura de Pantalla 2021-11-11 a la(s) 18 55 33" src="https://user-images.githubusercontent.com/48681779/141390524-6f0c4dcd-9edc-4ce8-8e28-3159a02885d3.png">


