### PR TITLE
Add Category Model

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,0 +1,16 @@
+# == Schema Information
+#
+# Table name: categories
+#
+#  id          :bigint           not null, primary key
+#  title       :string
+#  description :string
+#  group_id    :bigint           not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+class Category < ApplicationRecord
+  validates :title, presence: true
+  validates_length_of :title, minimum: 4
+  belongs_to :group
+end

--- a/db/migrate/20211123002429_create_categories.rb
+++ b/db/migrate/20211123002429_create_categories.rb
@@ -1,0 +1,11 @@
+class CreateCategories < ActiveRecord::Migration[6.1]
+  def change
+    create_table :categories do |t|
+      t.string :title
+      t.string :description
+      t.references :group, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_17_225213) do
+ActiveRecord::Schema.define(version: 2021_11_23_002429) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "categories", force: :cascade do |t|
+    t.string "title"
+    t.string "description"
+    t.bigint "group_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["group_id"], name: "index_categories_on_group_id"
+  end
 
   create_table "groups", force: :cascade do |t|
     t.string "name"
@@ -36,4 +45,5 @@ ActiveRecord::Schema.define(version: 2021_11_17_225213) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "categories", "groups"
 end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -1,0 +1,20 @@
+# == Schema Information
+#
+# Table name: categories
+#
+#  id          :bigint           not null, primary key
+#  title       :string
+#  description :string
+#  group_id    :bigint           not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+require 'rails_helper'
+
+RSpec.describe Category, type: :model do
+  describe 'validations' do
+    it { should validate_presence_of(:title) }
+    it { should belong_to(:group) }
+    it { should validate_length_of(:title).is_at_least(4) }
+  end
+end


### PR DESCRIPTION
This commit adds a category model and a craate categories migration in order to have an entity to store what kind of group are being created by the users.

# Description:
 - add a migration to create categories table with a group_id foreign key
 - add a Category model
 - add rspec model validations
 - add belongs to association to Group entity
 
 # Testing
rspec ./spec/models/category_spec.rb

  ## Screenshots
<img width="511" alt="Captura de Pantalla 2021-11-22 a la(s) 18 43 07" src="https://user-images.githubusercontent.com/48681779/142955715-3d6d5a34-5ccd-4b27-afa1-08e249053a83.png">

