### PR TITLE
Fix Groups and User Associations

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,6 +1,6 @@
 class GroupsController < ApplicationController
   before_action :set_group, only: [:show, :update, :destroy]
-  
+  before_action :authenticate_user!, :except => [:show, :index]
   def index
     @groups = Group.all
   end
@@ -12,8 +12,10 @@ class GroupsController < ApplicationController
 
   def create
     @group = Group.new(group_params)
+    @group.owner = current_user
+   
     if @group.save 
-      redirect_to @group
+      redirect_to @group, notice: 'Group was successfully created'
     else
       render :new
     end
@@ -29,7 +31,7 @@ class GroupsController < ApplicationController
     if @group.update(group_params)
       redirect_to @group
     else
-      render :edit
+      head :unprocessable_entity
     end
   end
 
@@ -43,6 +45,19 @@ class GroupsController < ApplicationController
       @group = Group.find params[:id]
     end
     def group_params 
-      params.require(:group).permit( :name, :description, :amount)
+      params.require(:group).permit( 
+        :name, 
+        :description, 
+        :amount,
+        :owner_id,
+        :category_id,
+        participating_users_attributes: [
+          :user_id,
+          :role,
+          :id,
+          :_destroy
+        ]
+
+      )
     end
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -12,5 +12,5 @@
 class Category < ApplicationRecord
   validates :title, presence: true
   validates_length_of :title, minimum: 4
-  belongs_to :group
+  has_many :groups
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -10,8 +10,13 @@
 #  updated_at  :datetime         not null
 #
 class Group < ApplicationRecord
- belongs_to :user
- has_and_belongs_to_many :users
+ belongs_to :owner, class_name: 'User'
+ has_many :participating_users, class_name: 'Participant'
+ has_many :participants, through: :participating_users, source: :user
+ belongs_to :category
+ validates :participating_users, presence: true 
+
  validates :name, :description, presence: true
  validates_numericality_of :amount
+ accepts_nested_attributes_for :participating_users, allow_destroy: true
 end

--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -1,0 +1,5 @@
+class Participant < ApplicationRecord
+    belongs_to :user
+    belongs_to :group
+    enum role: {responsible: 0, follower: 1}
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,10 +15,12 @@
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  has_one :owned_group, foreign_key: "user_id", class_name: "Group"
-  has_and_belongs_to_many :groups
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+  has_many :owned_groups, foreign_key: "owner_id", class_name: 'Group'
+  has_many :participations, class_name: 'Participant'
+  has_many :groups, through: :participations 
+  
   validates :email, :password, :role, presence: true
   validates :email, uniqueness: true
   #add enum for role integer field(User Free, User Premium and SuperAdmin User)

--- a/db/migrate/20211124002334_create_participants.rb
+++ b/db/migrate/20211124002334_create_participants.rb
@@ -1,0 +1,11 @@
+class CreateParticipants < ActiveRecord::Migration[6.1]
+  def change
+    create_table :participants do |t|
+      t.integer :role
+      t.references :user, null: false, foreign_key: true
+      t.references :group, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20211124004749_add_owner_to_group.rb
+++ b/db/migrate/20211124004749_add_owner_to_group.rb
@@ -1,0 +1,5 @@
+class AddOwnerToGroup < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :groups, :owner, null: false, foreign_key: { to_table: :users }, index: true 
+  end
+end

--- a/db/migrate/20211124005527_drop_join_table_users_groups.rb
+++ b/db/migrate/20211124005527_drop_join_table_users_groups.rb
@@ -1,0 +1,5 @@
+class DropJoinTableUsersGroups < ActiveRecord::Migration[6.1]
+  def change
+    drop_join_table :users, :groups 
+  end
+end

--- a/db/migrate/20211124162238_remove_group_from_categories.rb
+++ b/db/migrate/20211124162238_remove_group_from_categories.rb
@@ -1,0 +1,5 @@
+class RemoveGroupFromCategories < ActiveRecord::Migration[6.1]
+  def change
+    remove_reference :categories, :group, index: true, foreign_key: true
+  end
+end

--- a/db/migrate/20211124162501_add_category_to_groups.rb
+++ b/db/migrate/20211124162501_add_category_to_groups.rb
@@ -1,0 +1,5 @@
+class AddCategoryToGroups < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :groups, :category, null:false , index: true, foreign_key: true
+  end
+end

--- a/db/migrate/20211124164851_remove_user_references_from_groups.rb
+++ b/db/migrate/20211124164851_remove_user_references_from_groups.rb
@@ -1,0 +1,5 @@
+class RemoveUserReferencesFromGroups < ActiveRecord::Migration[6.1]
+  def change
+    remove_reference :groups, :user, index: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_22_235709) do
+ActiveRecord::Schema.define(version: 2021_11_24_164851) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -18,10 +18,8 @@ ActiveRecord::Schema.define(version: 2021_11_22_235709) do
   create_table "categories", force: :cascade do |t|
     t.string "title"
     t.string "description"
-    t.bigint "group_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["group_id"], name: "index_categories_on_group_id"
   end
 
   create_table "groups", force: :cascade do |t|
@@ -30,15 +28,20 @@ ActiveRecord::Schema.define(version: 2021_11_22_235709) do
     t.decimal "amount"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.bigint "user_id", null: false
-    t.index ["user_id"], name: "index_groups_on_user_id"
+    t.bigint "owner_id", null: false
+    t.bigint "category_id", null: false
+    t.index ["category_id"], name: "index_groups_on_category_id"
+    t.index ["owner_id"], name: "index_groups_on_owner_id"
   end
 
-  create_table "groups_users", id: false, force: :cascade do |t|
+  create_table "participants", force: :cascade do |t|
+    t.integer "role"
     t.bigint "user_id", null: false
     t.bigint "group_id", null: false
-    t.index ["group_id", "user_id"], name: "index_groups_users_on_group_id_and_user_id"
-    t.index ["user_id", "group_id"], name: "index_groups_users_on_user_id_and_group_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["group_id"], name: "index_participants_on_group_id"
+    t.index ["user_id"], name: "index_participants_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -54,9 +57,8 @@ ActiveRecord::Schema.define(version: 2021_11_22_235709) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
-  add_foreign_key "groups", "users"
-  add_foreign_key "groups_users", "groups"
-  add_foreign_key "groups_users", "users"
-  add_foreign_key "categories", "groups"
-
+  add_foreign_key "groups", "categories"
+  add_foreign_key "groups", "users", column: "owner_id"
+  add_foreign_key "participants", "groups"
+  add_foreign_key "participants", "users"
 end

--- a/spec/controllers/groups_spec.rb
+++ b/spec/controllers/groups_spec.rb
@@ -1,6 +1,9 @@
 require 'rails_helper'
 RSpec.describe GroupsController, type: :controller do
-    let(:group) { FactoryBot.create( :group )}
+    let(:user) { create :user  }
+    before(:each) {sign_in user}
+    let(:group) { FactoryBot.create( :group_with_participants )}
+    let(:category) { FactoryBot.create( :category )}
     it { should route(:get, '/groups').to(action: :index) }
     it { should route(:post, '/groups').to(action: :create) }
     it { should route(:get, '/groups/new').to(action: :new) }
@@ -15,7 +18,7 @@ RSpec.describe GroupsController, type: :controller do
             group: group.attributes
             }
             
-            should permit(:name,:description,:amount).
+            should permit(:name, :description, :amount , :owner_id, :category_id, { :participating_users_attributes => [:user_id, :role, :id, :_destroy]} ).
             for(:create, params: params).
             on(:group)
         end
@@ -27,7 +30,7 @@ RSpec.describe GroupsController, type: :controller do
                 group: group.attributes
             }
             
-            should permit(:name,:description,:amount).
+            should permit(:name, :description, :amount, :owner_id, :category_id, { :participating_users_attributes => [:user_id, :role, :id, :_destroy]} ).
             for(:update, params: params).
             on(:group)
         end

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+    factory :category do
+      title{Faker::Name.name}
+      description{Faker::Lorem.paragraph}
+    end
+  end
+  

--- a/spec/factories/groups.rb
+++ b/spec/factories/groups.rb
@@ -14,5 +14,22 @@ FactoryBot.define do
     name{Faker::App.name}
     description{Faker::Lorem.paragraph}
     amount{Faker::Number.decimal(l_digits: 2)}
+    category
+    association :owner, factory: :user
+    factory :group_with_participants do
+      transient do
+        participants_count {5} 
+      end
+      after(:build) do | group , evaluator|
+        group.participating_users = build_list(
+        :participant,
+        evaluator.participants_count,
+          group: group,
+          role: 1
+        )
+      end
+    end
+    
+
   end
 end

--- a/spec/factories/participants.rb
+++ b/spec/factories/participants.rb
@@ -1,0 +1,14 @@
+FactoryBot.define do
+    factory :participant do
+        association :user
+        trait :responsible do
+            role { Participant::ROLES[:responsible] }
+        end
+        trait :follower do
+            role { Participant::ROLES[:follower] }
+        end 
+        after(:build) do |participant, _|
+            participant.user.save
+        end
+    end
+end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -14,7 +14,7 @@ require 'rails_helper'
 RSpec.describe Category, type: :model do
   describe 'validations' do
     it { should validate_presence_of(:title) }
-    it { should belong_to(:group) }
+    it { should have_many(:groups) }
     it { should validate_length_of(:title).is_at_least(4) }
   end
 end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -12,8 +12,7 @@
 require 'rails_helper'
 
 RSpec.describe Group, type: :model do
-  let(:group) { FactoryBot.create( :group )}
-
+  
   describe 'validations' do
     it { should validate_presence_of(:name) }
     it { should validate_presence_of(:description) }
@@ -21,11 +20,12 @@ RSpec.describe Group, type: :model do
   end
 
   describe 'relationship' do
-    it { should belong_to(:user) }
+    it { should belong_to(:owner).class_name('User') }
+    it { should belong_to(:category) }
   end
 
   describe 'relationship has and belong to many' do
-    it { should have_and_belong_to_many(:users) }
+    it { should have_many(:participants) }
   end
 
 end

--- a/spec/models/participant_spec.rb
+++ b/spec/models/participant_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe Participant, type: :model do
+  
+  describe 'relationship' do
+    it { should belong_to(:user) }
+    it { should belong_to(:group) }
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -25,11 +25,11 @@ RSpec.describe User, type: :model do
 
 
   describe 'relationship' do
-    it { should have_one(:owned_group).class_name('Group') }
+    it { should have_many(:owned_groups).class_name('Group') }
   end
   
   describe 'relationship has and belong to many' do
-    it { should have_and_belong_to_many(:groups) }
+    it { should have_many(:groups) }
   end
 
   describe 'user roles enum validation' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -44,7 +44,7 @@ rescue ActiveRecord::PendingMigrationError => e
 end
 RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
-
+  config.include Warden::Test::Helpers 
   config.before(:suite) do
     DatabaseCleaner.strategy = :transaction
     DatabaseCleaner.clean_with(:truncation)
@@ -85,5 +85,8 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
-  config.include Devise::Test::IntegrationHelpers, type: :request
+
+  config.include Devise::Test::ControllerHelpers, type: 'controller'
+  config.include Devise::Test::IntegrationHelpers, type: 'request'
+
 end

--- a/spec/requests/groups_spec.rb
+++ b/spec/requests/groups_spec.rb
@@ -1,7 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe "Groups", type: :request do
-  let(:group) { FactoryBot.create( :group ) }
+  let(:user) { create :user  }
+  before(:each) {sign_in user}
   describe "GET groups#index" do
     it "should get index" do
       get "/groups"
@@ -15,25 +16,64 @@ RSpec.describe "Groups", type: :request do
     end
   end
   describe "POST groups#create" do 
-    it "should create a group with valid attributes and redirect" do
-      params = {
-        group: group.attributes
+   
+    let(:category) { FactoryBot.create(:category) }
+    let(:participant) { FactoryBot.create( :user) }
+    let(:params) do
+      { 
+        group: {
+          name:  "Name",
+          description: "Description",
+          amount: 30,
+          owner_id: user.id,
+          category_id: category.id,
+          participating_users_attributes: {
+            0 => {
+              user_id:  participant.id,
+              role: :follower,
+              _destroy: false
+            }
+          }
+         }
       }
+     
+    end
+    it "should create a group with valid attributes and redirect" do
+
       post '/groups', params: params
-      expect(response).to have_http_status(:redirect)
+      expect(response).to redirect_to(assigns(:group))
+      follow_redirect!
+      expect(response).to render_template(:show)
+      expect(response.body).to include('Group was successfully created')
+
     end
   end
   describe "UPDATE groups#update" do 
-    it 'should update the name and redirect' do
-      new_params = {
+    let(:category) { FactoryBot.create(:category) }
+    let(:group) { FactoryBot.create(:group_with_participants, participants_count: 10) }
+    let(:participant) { FactoryBot.create(:user) }
+    let(:new_params) do
+      { 
         group: {
-          name: 'New Name',
-          description: group.description,
-          amount: group.amount
-        }
-      }  
+          name:  "Name 2212",
+          description: "Description",
+          amount: 30,
+          owner_id: user.id,
+          category_id: category.id,
+          participating_users_attributes: {
+            0 => {
+              user_id:  participant.id,
+              role: :responsible,
+              _destroy: false
+            }
+          }
+         }
+      }
+    end
+    it 'should update the name and redirect' do
       put "/groups/#{group.id}", params: new_params
-      expect(response).to have_http_status(:redirect)
+      expect(response).to have_http_status(:redirect) 
+      expect(response).to_not have_http_status(:unprocessable_entity) 
     end
   end
 end


### PR DESCRIPTION


# Description
Add migrations for modify how the groups and user are associated, also a Category model was added  in order to create groups with a category given in tests, additional a Participant migration and model was added as a intermediate table and associate groups and users entities

 - remove user_id from groups and add owner_id
 - add Participant mode with role integer field to store if a participant is responsible or follower of the group
 - request and controller test update
 - add Category model in order to create groups
 - creation of groups, participants, and categories factories
 - add blank views new show and index erb files to its specific controller actions
 - add a warden and devise config line in rails_helpers rspec file in order to simulate sing in process in tests
 - add a callback to validate authentication in groups controllers

