### PR TITLE
Fix cocoon javascript dependency

### DIFF
--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,6 +1,10 @@
 const { environment } = require('@rails/webpacker')
 
 const webpack = require('webpack')
-
+environment.plugins.prepend('Provide',
+   new webpack.ProvidePlugin({
+       $: 'jquery/src/jquery',
+       jQuery: 'jquery/src/jquery'
+   })
+)
 module.exports = environment
-module.exports = webpack


### PR DESCRIPTION

# Description
Fix of environment webpack configuration file to deployment right compilation. We set a jquery as a dependency because is required by cocoon the library we decide to use in order to manage the nested forms adition for adding participants to groups
