### PR TITLE
Add individual and groups contribution budget

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -3,9 +3,8 @@
 # Table name: categories
 #
 #  id          :bigint           not null, primary key
-#  title       :string
 #  description :string
-#  group_id    :bigint           not null
+#  title       :string
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,13 +1,27 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: groups
 #
 #  id          :bigint           not null, primary key
-#  name        :string
-#  description :text
 #  amount      :decimal(, )
+#  description :text
+#  name        :string
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
+#  category_id :bigint           not null
+#  owner_id    :bigint           not null
+#
+# Indexes
+#
+#  index_groups_on_category_id  (category_id)
+#  index_groups_on_owner_id     (owner_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (category_id => categories.id)
+#  fk_rails_...  (owner_id => users.id)
 #
 class Group < ApplicationRecord
   belongs_to :owner, class_name: 'User'
@@ -15,7 +29,6 @@ class Group < ApplicationRecord
   has_many :participants, through: :participating_users, source: :user
   belongs_to :category
   validates :participating_users, presence: true
-
   validates :name, :description, presence: true
   validates_numericality_of :amount
   accepts_nested_attributes_for :participating_users, allow_destroy: true
@@ -28,5 +41,9 @@ class Group < ApplicationRecord
           { current_user_id: current_user_id }
         ]
       ).group(:id)
+  end
+
+  def individual_contribution
+    (amount / participants.count)
   end
 end

--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -1,5 +1,28 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: participants
+#
+#  id         :bigint           not null, primary key
+#  role       :integer
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  group_id   :bigint           not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_participants_on_group_id  (group_id)
+#  index_participants_on_user_id   (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (group_id => groups.id)
+#  fk_rails_...  (user_id => users.id)
+#
 class Participant < ApplicationRecord
-    belongs_to :user
-    belongs_to :group
-    enum role: {responsible: 0, follower: 1} , _default: 1
+  belongs_to :user
+  belongs_to :group
+  enum role: { responsible: 0, follower: 1 }, _default: 1
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: users
@@ -5,24 +7,34 @@
 #  id                     :bigint           not null, primary key
 #  email                  :string           default(""), not null
 #  encrypted_password     :string           default(""), not null
-#  role                   :integer          default("free")
-#  reset_password_token   :string
-#  reset_password_sent_at :datetime
 #  remember_created_at    :datetime
+#  reset_password_sent_at :datetime
+#  reset_password_token   :string
+#  role                   :integer          default("free")
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
+#
+# Indexes
+#
+#  index_users_on_email                 (email) UNIQUE
+#  index_users_on_reset_password_token  (reset_password_token) UNIQUE
 #
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
-  has_many :owned_groups, foreign_key: "owner_id", class_name: 'Group'
+  has_many :owned_groups, foreign_key: 'owner_id', class_name: 'Group'
   has_many :participations, class_name: 'Participant'
-  has_many :groups, through: :participations 
-  
+  has_many :groups, through: :participations
+
   validates :email, :password, :role, presence: true
   validates :email, uniqueness: true
-  #add enum for role integer field(User Free, User Premium and SuperAdmin User)
-  enum role: {free: 0, premium: 1, superadmin: 2}
+  # add enum for role integer field(User Free, User Premium and SuperAdmin User)
+  enum role: { free: 0, premium: 1, superadmin: 2 }
+  def groups_contribution
+    groups_owmed_amount = owned_groups.map(&:individual_contribution)
+    groups_particiations_amount = groups.map(&:individual_contribution)
+    (groups_owmed_amount.reduce(:+) + groups_particiations_amount.reduce(:+))
+  end
 end

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -1,4 +1,5 @@
 <h2>Groups for <%= current_user.email %> </h2>
+<h2>Amount Groups Contribution <%= number_to_currency(current_user.groups_contribution) %> </h2>
 <%= link_to 'New Group', new_group_path %>
 <table>
   <thead>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -1,19 +1,26 @@
 <p id="notice"><%= notice %></p>
-
+<p>
+  <strong>Administrator:</strong>
+  <%= @group.owner.email %>
+</p>
 <p>
   <strong>Group Name:</strong>
   <%= @group.name %>
 </p>
-
 <p>
   <strong>Group Description:</strong>
   <%= @group.description %>
 </p>
+<p>
+  <strong>Group Amount:</strong>
+  <%=number_to_currency(@group.amount,locale: :en) %>
+</p>
 <strong>Participants:</strong>
 <%@group.participants.each do |participant| %>
-    <p><%=participant.email%></p>
+  <div class="d-flex">
+    <span> <strong>Email:</strong> <%=participant.email%></span>
+    <span class="mx-2"> <strong>Contribution:</strong> <%=number_to_currency(@group.individual_contribution)%></span>
+  </div>
 <% end %>
-
-
 <%= link_to 'Edit', edit_group_path(@group) %> |
 <%= link_to 'Back', groups_path %>

--- a/lib/tasks/auto_annotate_models.rake
+++ b/lib/tasks/auto_annotate_models.rake
@@ -1,0 +1,59 @@
+# NOTE: only doing this in development as some production environments (Heroku)
+# NOTE: are sensitive to local FS writes, and besides -- it's just not proper
+# NOTE: to have a dev-mode tool do its thing in production.
+if Rails.env.development?
+  require 'annotate'
+  task :set_annotation_options do
+    # You can override any of these by setting an environment variable of the
+    # same name.
+    Annotate.set_defaults(
+      'active_admin'                => 'false',
+      'additional_file_patterns'    => [],
+      'routes'                      => 'false',
+      'models'                      => 'true',
+      'position_in_routes'          => 'before',
+      'position_in_class'           => 'before',
+      'position_in_test'            => 'before',
+      'position_in_fixture'         => 'before',
+      'position_in_factory'         => 'before',
+      'position_in_serializer'      => 'before',
+      'show_foreign_keys'           => 'true',
+      'show_complete_foreign_keys'  => 'false',
+      'show_indexes'                => 'true',
+      'simple_indexes'              => 'false',
+      'model_dir'                   => 'app/models',
+      'root_dir'                    => '',
+      'include_version'             => 'false',
+      'require'                     => '',
+      'exclude_tests'               => 'true',
+      'exclude_fixtures'            => 'true',
+      'exclude_factories'           => 'true',
+      'exclude_serializers'         => 'false',
+      'exclude_scaffolds'           => 'true',
+      'exclude_controllers'         => 'true',
+      'exclude_helpers'             => 'true',
+      'exclude_sti_subclasses'      => 'false',
+      'ignore_model_sub_dir'        => 'false',
+      'ignore_columns'              => nil,
+      'ignore_routes'               => nil,
+      'ignore_unknown_models'       => 'false',
+      'hide_limit_column_types'     => 'integer,bigint,boolean',
+      'hide_default_column_types'   => 'json,jsonb,hstore',
+      'skip_on_db_migrate'          => 'false',
+      'format_bare'                 => 'true',
+      'format_rdoc'                 => 'false',
+      'format_yard'                 => 'false',
+      'format_markdown'             => 'false',
+      'sort'                        => 'false',
+      'force'                       => 'false',
+      'frozen'                      => 'false',
+      'classified_sort'             => 'true',
+      'trace'                       => 'false',
+      'wrapper_open'                => nil,
+      'wrapper_close'               => nil,
+      'with_comment'                => 'true'
+    )
+  end
+
+  Annotate.load_tasks
+end


### PR DESCRIPTION
# Description
Add method to user an group models in order to get the spent or contribution of a participant in a group

What did you implemented/Why did you implemented this:
 - get individual contribution 
 - get budget by owned groups and participation groups
 - annotate initial and default setting
 - annotation of models

  ## Screenshots
<img width="731" alt="Captura de Pantalla 2021-11-30 a la(s) 18 45 57" src="https://user-images.githubusercontent.com/48681779/144262610-f8e28e63-b4fc-4062-9bb5-dc6916dbc4ac.png">
<img width="611" alt="Captura de Pantalla 2021-11-30 a la(s) 18 46 04" src="https://user-images.githubusercontent.com/48681779/144262617-47d70ffc-d5d7-4f3a-88f3-33aa5446eafd.png">
