### PR TITLE
Fix Individual Contribution for the amount in the group

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -63,7 +63,11 @@ class Group < ApplicationRecord
       ).group(:id)
   end
 
+  def quantity_of_people_in_group
+    participating_users.size + 1
+  end
+
   def individual_contribution
-    (amount / participants.count)
+    (amount / quantity_of_people_in_group)
   end
 end

--- a/spec/factories/groups.rb
+++ b/spec/factories/groups.rb
@@ -11,25 +11,23 @@
 #
 FactoryBot.define do
   factory :group do
-    name{Faker::App.name}
-    description{Faker::Lorem.paragraph}
-    amount{Faker::Number.decimal(l_digits: 2)}
+    name { Faker::App.name }
+    description { Faker::Lorem.paragraph }
+    amount { Faker::Number.decimal(l_digits: 2) }
     category
     association :owner, factory: :user
     factory :group_with_participants do
       transient do
-        participants_count {5} 
+        participants_count { 5 }
       end
-      after(:build) do | group , evaluator|
+      after(:build) do |group, evaluator|
         group.participating_users = build_list(
-        :participant,
-        evaluator.participants_count,
+          :participant,
+          evaluator.participants_count,
           group: group,
           role: 1
         )
       end
     end
-    
-
   end
 end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -12,7 +12,7 @@
 require 'rails_helper'
 
 RSpec.describe Group, type: :model do
-  
+  let(:group) { FactoryBot.create(:group_with_participants) }
   describe 'validations' do
     it { should validate_presence_of(:name) }
     it { should validate_presence_of(:description) }
@@ -28,4 +28,12 @@ RSpec.describe Group, type: :model do
     it { should have_many(:participants) }
   end
 
+  describe 'contributions calculate' do
+    it 'should 6 peoples intrating the group' do
+      expect(group.quantity_of_people_in_group).to eq(6)
+    end
+    it 'should have equitative contributions between participants and the admin of the group' do
+      expect(group.individual_contribution.to_f).to eq(group.amount.to_f / group.quantity_of_people_in_group)
+    end
+  end
 end


### PR DESCRIPTION
# Description
Refactor of a code for individual_contribution method to calculate the contribution between all the people inside a group not only the participants of the groups without the admin of the same.