### PR TITLE
Hotfix groups card mobile

### DIFF
--- a/app/views/groups/_form.html.erb
+++ b/app/views/groups/_form.html.erb
@@ -1,17 +1,20 @@
 <%= simple_form_for @group do |f| %>
 	<% if @group.errors.any? %>
 		<div id="error_explanation" class="container">
-			<div class="col-6 offset-3">
+			<div class="col-12 col-md-6 offset-md-3 mt-3">
 				<h2><%= pluralize(@group.errors.count, "error") %> prohibited this group from being saved:</h2>
 				<ul>
 					<% @group.errors.each do |error| %>
 						<li><%= error.full_message %></li>
 					<% end %>
 				</ul>
+				
 			</div>
 		</div>
 	<% end %>
-	<div class="form-group col-6 offset-3 my-2">
+
+	<div class="form-group col-12 col-md-6 offset-md-3 my-2">
+		<hr>
 		<%= f.input :name, :input_html => { :class => 'form-control my-2' } %>
 		<%= f.input :description, as: :text, :input_html => { :class => 'form-control my-2' } %>
 		<%= f.input :amount, :input_html => { :class => 'form-control my-2' } %>
@@ -28,7 +31,7 @@
 			<div class="participants-container"></div>
 		</div>
 	</div>
-	<div class="col-6 offset-3 border-top border-gray mt-3 pt-3">
+	<div class="col-12 col-md-6 offset-md-3 border-top border-gray mt-3 pt-3">
 		<%= f.button :submit , class:'btn btn-dark col-12 mb-3 py-3'  %>
 	</div>
 <%end%>

--- a/app/views/groups/_group.html.erb
+++ b/app/views/groups/_group.html.erb
@@ -1,4 +1,4 @@
-<div class="card mb-3 col-4 border-0 text-dark nav-link">
+<div class="card mb-3 col-12 col-md-4 border-0 text-dark nav-link">
 	<%= image_tag "https://dummyimage.com/600x400/000000/9e9e9e&text=#{group.name.parameterize(separator:'+')}", alt: 'src', class:'card-img-top' %>
 	<div class="card-body">
 		<%= link_to group, class:'text-dark nav-link text-center text-uppercase border-bottom border-dark mb-2' do %>

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -1,15 +1,22 @@
 <div class="container">
-	<h2>Groups Contribution: <%= number_to_currency(current_user.groups_contribution) %> </h2>
+	<div class="row my-3">
+		<h2>Groups Contribution: <%= number_to_currency(current_user.groups_contribution) %> </h2>
+	</div>
+	<hr>
 	<div class="row">
-		<h3>My Groups</h3>
+			<h3>My Groups</h3>
+	</div>
+	<div class="row">
 		<%= render @groups_owned %>
 	</div>
 	<div class="row">
 		<h3>Groups where i am</h3>
+	</div>
+	<div class="row">
 		<%= render @groups %>
 	</div>
 	<div class="row">
-		<div class="d-flex my-5 justify-content-center flex-column col-6 offset-3">
+		<div class="d-flex my-5 justify-content-center flex-column col-12 col-md-6 offset-md-3">
 			<%=create_group_button(current_user) %>
 		</div>
 	</div>

--- a/app/views/groups/new.html.erb
+++ b/app/views/groups/new.html.erb
@@ -1,4 +1,4 @@
 <div class="container">
-  <h1 class="text-center">New Group</h1>
+  <h1 class="text-center mt-4">New Group</h1>
   <%= render "form"%>
 </div>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -1,11 +1,11 @@
 <div class="container">
-	<div class="row">
-		<div class="col-6 offset-3">
+	<div class="row mt-4">
+		<div class="col-12 col-md-6 offset-md-3">
 			<%= image_tag "https://dummyimage.com/600x400/000000/9e9e9e&text=#{@group.name.parameterize(separator:'+')}", alt: 'src', class:'img-fluid' %>
 		</div>
 	</div>
 	<div class="row">
-		<div class="col-6 offset-3">
+		<div class="col-12 col-md-6 offset-md-3">
 			<p id="notice"><%= notice %></p>
 			<p>
 				<strong>Administrator:</strong>
@@ -26,13 +26,13 @@
 			<div class="my-3">
 				<strong>Participants:</strong>
 				<%@group.participants.each do |participant| %>
-					<div class="d-flex">
+					<div class="d-flex flex-wrap">
 						<span> <strong>Email:</strong> <%=participant.email%></span>
-						<span class="mx-2"> <strong>Contribution:</strong> <%=number_to_currency(@group.individual_contribution)%></span>
+						<span class="mx-0 mx-md-2"> <strong>Contribution:</strong> <%=number_to_currency(@group.individual_contribution)%></span>
 					</div>
 				<% end %>
 			</div>
-			<div class="row border-top border-gray mt-3 pt-3 mb-5 justify-content-between">
+			<div class="col-12 d-flex border-top border-gray mt-3 pt-3 mb-5 justify-content-between">
 				<%= link_to 'Edit', edit_group_path(@group), class:'btn btn-outline-dark col-5' %>
 				<%= link_to 'Back', groups_path , class:'btn btn-outline-dark col-5'%>
 			</div>


### PR DESCRIPTION
# Description
This commit is a fix for booststrap mobile clases to have a right mobile presentation of the groups in phone devices.

## Screenshots
<img width="319" alt="Captura de Pantalla 2021-12-09 a la(s) 13 16 26" src="https://user-images.githubusercontent.com/48681779/145461098-d85ce2b0-5eda-4280-9f7e-c8863881aac5.png">

